### PR TITLE
 Add Shared Grid Component

### DIFF
--- a/src/components/shared/Grid/Grid.styles.js
+++ b/src/components/shared/Grid/Grid.styles.js
@@ -3,16 +3,23 @@ import Box from '@mui/material/Box';
 import Grid from '@mui/material/Grid';
 import Paper from '@mui/material/Paper';
 
-export const StyledBox = styled(Box)({
+export const defaultColumns = { xs: 4, sm: 8, md: 12 };
+export const defaultSpacing = { xs: 2, md: 3 };
+export const defaultItemSize = { xs: 2, sm: 4, md: 4 };
+export const defaultStyle = {};
+
+export const StyledBox = styled(Box)(({ theme }) => ({
   width: '100%',
-});
+  flexGrow: 1,
+}));
+
 
 export const StyledGrid = styled(Grid)(({ theme }) => ({
   display: 'flex',
 }));
 
 export const StyledItem = styled(Paper)(({ theme }) => ({
-  backgroundColor: '#fff',
+  backgroundColor: theme.palette.background.paper,
   ...theme.typography.body2,
   padding: theme.spacing(2),
   textAlign: 'center',

--- a/src/components/shared/Grid/Grid.styles.js
+++ b/src/components/shared/Grid/Grid.styles.js
@@ -1,0 +1,20 @@
+import { styled } from '@mui/material/styles';
+import Box from '@mui/material/Box';
+import Grid from '@mui/material/Grid';
+import Paper from '@mui/material/Paper';
+
+export const StyledBox = styled(Box)({
+  width: '100%',
+});
+
+export const StyledGrid = styled(Grid)(({ theme }) => ({
+  display: 'flex',
+}));
+
+export const StyledItem = styled(Paper)(({ theme }) => ({
+  backgroundColor: '#fff',
+  ...theme.typography.body2,
+  padding: theme.spacing(2),
+  textAlign: 'center',
+  color: theme.palette.text.secondary,
+}));

--- a/src/components/shared/Grid/SharedGrid.jsx
+++ b/src/components/shared/Grid/SharedGrid.jsx
@@ -10,7 +10,7 @@ function SharedGrid({
   columns = defaultColumns,
   spacing = defaultSpacing,
   itemSize = defaultItemSize,
-  style = defaultStyle,
+  style = {},
   ...rest
 }) {
   return (

--- a/src/components/shared/Grid/SharedGrid.jsx
+++ b/src/components/shared/Grid/SharedGrid.jsx
@@ -1,9 +1,5 @@
 import * as React from 'react';
 import {
-  defaultColumns,
-  defaultSpacing,
-  defaultItemSize,
-  defaultStyle,
   StyledBox,
   StyledGrid,
   StyledItem

--- a/src/components/shared/Grid/SharedGrid.jsx
+++ b/src/components/shared/Grid/SharedGrid.jsx
@@ -1,0 +1,30 @@
+import * as React from 'react';
+import { StyledBox, StyledGrid, StyledItem } from './Grid.styles';
+
+function SharedGrid({
+  items = [],
+  columns = { xs: 4, sm: 8, md: 12 },
+  spacing = { xs: 2, md: 3 },
+  itemSize = { xs: 2, sm: 4, md: 4 },
+  style = {},
+  ...rest
+}) {
+  return (
+    <StyledBox sx={{ flexGrow: 1 }} style={style}>
+      <StyledGrid
+        container
+        spacing={spacing}
+        columns={columns}
+        {...rest}
+      >
+        {items.map((item, index) => (
+          <StyledGrid item key={index} {...itemSize}>
+            <StyledItem>{item}</StyledItem>
+          </StyledGrid>
+        ))}
+      </StyledGrid>
+    </StyledBox>
+  );
+}
+
+export default SharedGrid;

--- a/src/components/shared/Grid/SharedGrid.jsx
+++ b/src/components/shared/Grid/SharedGrid.jsx
@@ -1,25 +1,33 @@
 import * as React from 'react';
-import { StyledBox, StyledGrid, StyledItem } from './Grid.styles';
+import {
+  defaultColumns,
+  defaultSpacing,
+  defaultItemSize,
+  defaultStyle,
+  StyledBox,
+  StyledGrid,
+  StyledItem
+} from './Grid.styles';
 
 function SharedGrid({
   items = [],
-  columns = { xs: 4, sm: 8, md: 12 },
-  spacing = { xs: 2, md: 3 },
-  itemSize = { xs: 2, sm: 4, md: 4 },
-  style = {},
+  columns = defaultColumns,
+  spacing = defaultSpacing,
+  itemSize = defaultItemSize,
+  style = defaultStyle,
   ...rest
 }) {
   return (
-    <StyledBox sx={{ flexGrow: 1 }} style={style}>
+    <StyledBox style={style}>
       <StyledGrid
         container
         spacing={spacing}
         columns={columns}
         {...rest}
       >
-        {items.map((item, index) => (
-          <StyledGrid item key={index} {...itemSize}>
-            <StyledItem>{item}</StyledItem>
+        {items.map((item) => (
+          <StyledGrid item key={item.id} {...itemSize}>
+            <StyledItem>{item.description}</StyledItem>
           </StyledGrid>
         ))}
       </StyledGrid>

--- a/src/theme/theme.js
+++ b/src/theme/theme.js
@@ -1,6 +1,7 @@
 import { createTheme } from "@mui/material/styles";
 
 const theme = createTheme({
+  spacing: 8,
   palette: {
     background: {
       default: "#f5f5f5",


### PR DESCRIPTION
This PR introduces a new shared `SharedGrid` component based on MUI's Grid system.
The component enables flexible display of items with customizable columns, spacing, and item size, while maintaining a consistent style.

Features:
- `items`: Array of items to display.
- `columns`: Defines the number of columns based on screen size.
- `spacing`: Controls the spacing between grid items.
- `itemSize`: Defines how many columns each item should span.

The component is fully reusable and styled using MUI's theme system.
