### PR TITLE
Add children support to SharedButton and SharedLinkButton components

### DIFF
--- a/src/components/shared/Button/SharedButton.jsx
+++ b/src/components/shared/Button/SharedButton.jsx
@@ -1,10 +1,10 @@
 import React from 'react';
 import { StyledButton } from './Button.styles';
 
-function SharedButton({ label, style = {}, ...rest }) {
+function SharedButton({ label, children, style = {}, ...rest }) {
   return (
     <StyledButton sx={style} {...rest}>
-      {label}
+      {children || label}
     </StyledButton>
   );
 }

--- a/src/components/shared/Button/SharedLinkButton.jsx
+++ b/src/components/shared/Button/SharedLinkButton.jsx
@@ -2,10 +2,10 @@ import React from 'react';
 import { Link } from 'react-router-dom';
 import { StyledButton } from './Button.styles';
 
-function SharedLinkButton({ label, to, style = {}, ...rest }) {
+function SharedLinkButton({ label, children, to, style = {}, ...rest }) {
   return (
     <StyledButton component={Link} to={to} sx={style} {...rest}>
-      {label}
+      {children || label}
     </StyledButton>
   );
 }


### PR DESCRIPTION
This PR introduces a small but meaningful enhancement to the shared button components:

🔧 Changes Made:
Updated SharedButton to support children as an alternative to the label prop.

Updated SharedLinkButton similarly to support children.

Fallback to label if no children are provided, preserving backward compatibility.

🎯 Why This Change?
This update improves flexibility by allowing developers to:

Pass icons, custom markup, or any JSX element as button content.

Avoid being limited to plain text label values.

Maintain concise syntax with <SharedButton>Click Me</SharedButton> if preferred.

✅ Compatibility:
Fully backward compatible: existing uses of label remain functional.

No breaking changes introduced.